### PR TITLE
Fix api validation to bubble up error  message from client to provider level

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,9 +2,12 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -66,6 +69,70 @@ func NewClient(baseUrl, authHeader string) *Client {
 	}
 }
 
+type APIError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Message)
+}
+
+func handleAPIError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	errStr := err.Error()
+
+	re := regexp.MustCompile(`\[(\d+)\] \w+ (.+)`)
+	matches := re.FindStringSubmatch(errStr)
+
+	if len(matches) == 3 {
+		jsonStr := matches[2]
+
+		var jsonError struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
+
+		if err := json.Unmarshal([]byte(jsonStr), &jsonError); err == nil {
+			return &APIError{
+				StatusCode: jsonError.Code,
+				Message:    jsonError.Message,
+			}
+		}
+	}
+
+	v := reflect.ValueOf(err)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	var statusCode int
+	var message string
+
+	if codeMethod := v.MethodByName("Code"); codeMethod.IsValid() {
+		if codeValue := codeMethod.Call(nil)[0]; codeValue.CanInt() {
+			statusCode = int(codeValue.Int())
+		}
+	}
+
+	if v.Kind() == reflect.Struct {
+		if messageField := v.FieldByName("Message"); messageField.IsValid() && messageField.Kind() == reflect.String {
+			message = messageField.String()
+		}
+	}
+
+	if statusCode != 0 && message != "" {
+		return &APIError{
+			StatusCode: statusCode,
+			Message:    message,
+		}
+	}
+
+	return err
+}
 
 func (c *Client) GetDatabases(ctx context.Context) ([]*models.Database, error) {
 	request := &operations.GetDatabasesParams{
@@ -77,7 +144,7 @@ func (c *Client) GetDatabases(ctx context.Context) ([]*models.Database, error) {
 
 	resp, err := c.PgEdgeAPIClient.Operations.GetDatabases(request)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIError(err)
 	}
 
 	return resp.Payload, nil
@@ -93,14 +160,14 @@ func (c *Client) CreateDatabase(ctx context.Context, database *models.CreateData
 
 	resp, err := c.PgEdgeAPIClient.Operations.PostDatabases(request)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIError(err)
 	}
 
 	// Poll for database creation
 	for {
 		databaseDetails, err := c.GetDatabase(ctx, *resp.Payload.ID)
 		if err != nil {
-			return nil, err
+			return nil, handleAPIError(err)
 		}
 
 		if databaseDetails.Status == nil {
@@ -131,7 +198,7 @@ func (c *Client) GetDatabase(ctx context.Context, id strfmt.UUID) (*models.Datab
 
 	resp, err := c.PgEdgeAPIClient.Operations.GetDatabasesID(request)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIError(err)
 	}
 
 	return resp.Payload, nil
@@ -149,14 +216,14 @@ func (c *Client) UpdateDatabase(ctx context.Context, id strfmt.UUID, body *model
 
 	resp, err := c.PgEdgeAPIClient.Operations.PatchDatabasesID(request)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIError(err)
 	}
 
 	// Poll for database update
 	for {
 		databaseDetails, err := c.GetDatabase(ctx, *resp.Payload.ID)
 		if err != nil {
-			return nil, err
+			return nil, handleAPIError(err)
 		}
 
 		if databaseDetails.Status == nil {
@@ -195,9 +262,9 @@ func (c *Client) DeleteDatabase(ctx context.Context, id strfmt.UUID) error {
 
 			time.Sleep(5 * time.Second)
 		}
+	} else {
+		return handleAPIError(err)
 	}
-
-	return nil
 }
 
 func (c *Client) GetAllClusters(ctx context.Context) ([]*models.Cluster, error) {
@@ -210,7 +277,7 @@ func (c *Client) GetAllClusters(ctx context.Context) ([]*models.Cluster, error) 
 
 	resp, err := c.PgEdgeAPIClient.Operations.GetClusters(request)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIError(err)
 	}
 
 	return resp.Payload, nil
@@ -227,7 +294,7 @@ func (c *Client) GetCluster(ctx context.Context, id strfmt.UUID) (*models.Cluste
 
 	resp, err := c.PgEdgeAPIClient.Operations.GetClustersID(request)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIError(err)
 	}
 
 	return resp.Payload, nil
@@ -244,13 +311,13 @@ func (c *Client) CreateCluster(ctx context.Context, cluster *models.CreateCluste
 
 	resp, err := c.PgEdgeAPIClient.Operations.PostClusters(request)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIError(err)
 	}
 
 	for {
 		clusterDetails, err := c.GetCluster(ctx, strfmt.UUID(*resp.Payload.ID))
 		if err != nil {
-			return nil, err
+			return nil, handleAPIError(err)
 		}
 
 		switch *clusterDetails.Status {
@@ -278,13 +345,13 @@ func (c *Client) UpdateCluster(ctx context.Context, id strfmt.UUID, body *models
 
 	resp, err := c.PgEdgeAPIClient.Operations.PatchClustersID(request)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIError(err)
 	}
 
 	for {
 		clusterDetails, err := c.GetCluster(ctx, strfmt.UUID(*resp.Payload.ID))
 		if err != nil {
-			return nil, err
+			return nil, handleAPIError(err)
 		}
 
 		switch *clusterDetails.Status {
@@ -318,9 +385,9 @@ func (c *Client) DeleteCluster(ctx context.Context, id strfmt.UUID) error {
 			}
 			time.Sleep(5 * time.Second)
 		}
+	} else {
+		return handleAPIError(err)
 	}
-
-	return nil
 }
 
 func (c *Client) GetClusterNodes(ctx context.Context, id strfmt.UUID, nearLat, nearLon, orderBy *string) ([]*models.ClusterNode, error) {
@@ -337,7 +404,7 @@ func (c *Client) GetClusterNodes(ctx context.Context, id strfmt.UUID, nearLat, n
 
 	resp, err := c.PgEdgeAPIClient.Operations.GetClustersIDNodes(request)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIError(err)
 	}
 
 	return resp.Payload, nil
@@ -365,17 +432,13 @@ func (c *Client) GetClusterNodeLogs(ctx context.Context, clusterID, nodeID strfm
 
 	resp, err := c.PgEdgeAPIClient.Operations.GetClustersIDNodesNodeIDLogsLogName(request)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIError(err)
 	}
 
 	return resp.Payload, nil
 }
 
 func (c *Client) GetCloudAccounts(ctx context.Context) ([]*models.CloudAccount, error) {
-	if c.PgEdgeAPIClient == nil {
-		return nil, fmt.Errorf("PgEdgeAPIClient is nil")
-	}
-
 	request := &operations.GetCloudAccountsParams{
 		HTTPClient: c.HTTPClient,
 		Context:    ctx,
@@ -385,7 +448,7 @@ func (c *Client) GetCloudAccounts(ctx context.Context) ([]*models.CloudAccount, 
 
 	resp, err := c.PgEdgeAPIClient.Operations.GetCloudAccounts(request)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIError(err)
 	}
 
 	return resp.Payload, nil
@@ -402,7 +465,7 @@ func (c *Client) GetCloudAccount(ctx context.Context, id strfmt.UUID) (*models.C
 
 	resp, err := c.PgEdgeAPIClient.Operations.GetCloudAccountsID(request)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIError(err)
 	}
 
 	return resp.Payload, nil
@@ -418,7 +481,7 @@ func (c *Client) CreateCloudAccount(ctx context.Context, account *models.CreateC
 
 	resp, err := c.PgEdgeAPIClient.Operations.PostCloudAccounts(request)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIError(err)
 	}
 
 	return resp.Payload, nil
@@ -435,162 +498,165 @@ func (c *Client) DeleteCloudAccount(ctx context.Context, id strfmt.UUID) error {
 
 	_, err := c.PgEdgeAPIClient.Operations.DeleteCloudAccountsID(request)
 	if err != nil {
-		return err
+		return handleAPIError(err)
 	}
 
 	return nil
 }
 
 func (c *Client) GetSSHKeys(ctx context.Context) ([]*models.SSHKey, error) {
-    request := &operations.GetSSHKeysParams{
-        HTTPClient: c.HTTPClient,
-        Context:    ctx,
-    }
+	request := &operations.GetSSHKeysParams{
+		HTTPClient: c.HTTPClient,
+		Context:    ctx,
+	}
 
-    request.SetAuthorization(c.AuthHeader)
+	request.SetAuthorization(c.AuthHeader)
 
-    resp, err := c.PgEdgeAPIClient.Operations.GetSSHKeys(request)
-    if err != nil {
-        return nil, err
-    }
+	resp, err := c.PgEdgeAPIClient.Operations.GetSSHKeys(request)
+	if err != nil {
+		return nil, handleAPIError(err)
+	}
 
-    return resp.Payload, nil
+	return resp.Payload, nil
 }
 
 func (c *Client) CreateSSHKey(ctx context.Context, sshKey *models.CreateSSHKeyInput) (*models.SSHKey, error) {
-    request := &operations.PostSSHKeysParams{
-        HTTPClient: c.HTTPClient,
-        Context:    ctx,
-        Body:       sshKey,
-    }
-    request.SetAuthorization(c.AuthHeader)
+	request := &operations.PostSSHKeysParams{
+		HTTPClient: c.HTTPClient,
+		Context:    ctx,
+		Body:       sshKey,
+	}
+	request.SetAuthorization(c.AuthHeader)
 
-    resp, err := c.PgEdgeAPIClient.Operations.PostSSHKeys(request)
-    if err != nil {
-        return nil, err
-    }
+	resp, err := c.PgEdgeAPIClient.Operations.PostSSHKeys(request)
+	if err != nil {
+		return nil, handleAPIError(err)
+	}
 
-    return resp.Payload, nil
+	return resp.Payload, nil
 }
 
 func (c *Client) GetSSHKey(ctx context.Context, id strfmt.UUID) (*models.SSHKey, error) {
-    request := &operations.GetSSHKeysIDParams{
-        HTTPClient: c.HTTPClient,
-        Context:    ctx,
-        ID:         id,
-    }
+	request := &operations.GetSSHKeysIDParams{
+		HTTPClient: c.HTTPClient,
+		Context:    ctx,
+		ID:         id,
+	}
 
-    request.SetAuthorization(c.AuthHeader)
+	request.SetAuthorization(c.AuthHeader)
 
-    resp, err := c.PgEdgeAPIClient.Operations.GetSSHKeysID(request)
-    if err != nil {
-        return nil, err
-    }
+	resp, err := c.PgEdgeAPIClient.Operations.GetSSHKeysID(request)
+	if err != nil {
+		return nil, handleAPIError(err)
+	}
 
-    return resp.Payload, nil
+	return resp.Payload, nil
 }
 
 func (c *Client) DeleteSSHKey(ctx context.Context, id strfmt.UUID) error {
-    request := &operations.DeleteSSHKeysIDParams{
-        HTTPClient: c.HTTPClient,
-        Context:    ctx,
-        ID:         id,
-    }
+	request := &operations.DeleteSSHKeysIDParams{
+		HTTPClient: c.HTTPClient,
+		Context:    ctx,
+		ID:         id,
+	}
 
-    request.SetAuthorization(c.AuthHeader)
+	request.SetAuthorization(c.AuthHeader)
 
-    _, err := c.PgEdgeAPIClient.Operations.DeleteSSHKeysID(request)
-    return err
+	_, err := c.PgEdgeAPIClient.Operations.DeleteSSHKeysID(request)
+	if err != nil {
+		return handleAPIError(err)
+	}
+	 return nil
 }
 
 func (c *Client) GetBackupStores(ctx context.Context, createdAfter, createdBefore *string, limit, offset *int64, descending *bool) ([]*models.BackupStore, error) {
-    request := &operations.GetBackupStoresParams{
-        HTTPClient:    c.HTTPClient,
-        Context:       ctx,
-        CreatedAfter:  createdAfter,
-        CreatedBefore: createdBefore,
-        Limit:         limit,
-        Offset:        offset,
-        Descending:    descending,
-    }
+	request := &operations.GetBackupStoresParams{
+		HTTPClient:    c.HTTPClient,
+		Context:       ctx,
+		CreatedAfter:  createdAfter,
+		CreatedBefore: createdBefore,
+		Limit:         limit,
+		Offset:        offset,
+		Descending:    descending,
+	}
 
-    request.SetAuthorization(c.AuthHeader)
+	request.SetAuthorization(c.AuthHeader)
 
-    resp, err := c.PgEdgeAPIClient.Operations.GetBackupStores(request)
-    if err != nil {
-        return nil, err
-    }
+	resp, err := c.PgEdgeAPIClient.Operations.GetBackupStores(request)
+	if err != nil {
+		return nil, handleAPIError(err)
+	}
 
-    return resp.Payload, nil
+	return resp.Payload, nil
 }
 
 func (c *Client) CreateBackupStore(ctx context.Context, input *models.CreateBackupStoreInput) (*models.BackupStore, error) {
-    request := &operations.PostBackupStoresParams{
-        HTTPClient: c.HTTPClient,
-        Context:    ctx,
-        Body:       input,
-    }
+	request := &operations.PostBackupStoresParams{
+		HTTPClient: c.HTTPClient,
+		Context:    ctx,
+		Body:       input,
+	}
 
-    request.SetAuthorization(c.AuthHeader)
+	request.SetAuthorization(c.AuthHeader)
 
-    resp, err := c.PgEdgeAPIClient.Operations.PostBackupStores(request)
-    if err != nil {
-        return nil, err
-    }
+	resp, err := c.PgEdgeAPIClient.Operations.PostBackupStores(request)
+	if err != nil {
+		return nil, handleAPIError(err)
+	}
 
 	if resp == nil || resp.Payload == nil {
-        return nil, fmt.Errorf("received nil response or payload")
-    }
+		return nil, fmt.Errorf("received nil response or payload")
+	}
 
 	backupStore := resp.Payload
 
-    for {
-        updatedStore, err := c.GetBackupStore(ctx, *backupStore.ID)
-        if err != nil {
-            return nil, fmt.Errorf("error checking backup store status: %w", err)
-        }
+	for {
+		updatedStore, err := c.GetBackupStore(ctx, *backupStore.ID)
+		if err != nil {
+			return nil, handleAPIError(err)
+		}
 
-        switch *updatedStore.Status {
-        case "available":
-            return updatedStore, nil
-        case "failed":
-            return nil, errors.New("backup store creation failed")
-        case "creating":
-            time.Sleep(5 * time.Second)
-        default:
-            return nil, fmt.Errorf("unexpected backup store status: %s", *updatedStore.Status)
-        }
-    }
+		switch *updatedStore.Status {
+		case "available":
+			return updatedStore, nil
+		case "failed":
+			return nil, errors.New("backup store creation failed")
+		case "creating":
+			time.Sleep(5 * time.Second)
+		default:
+			return nil, fmt.Errorf("unexpected backup store status: %s", *updatedStore.Status)
+		}
+	}
 }
 
 func (c *Client) GetBackupStore(ctx context.Context, id strfmt.UUID) (*models.BackupStore, error) {
-    request := &operations.GetBackupStoresIDParams{
-        HTTPClient: c.HTTPClient,
-        Context:    ctx,
-        ID:         id,
-    }
+	request := &operations.GetBackupStoresIDParams{
+		HTTPClient: c.HTTPClient,
+		Context:    ctx,
+		ID:         id,
+	}
 
-    request.SetAuthorization(c.AuthHeader)
+	request.SetAuthorization(c.AuthHeader)
 
-    resp, err := c.PgEdgeAPIClient.Operations.GetBackupStoresID(request)
-    if err != nil {
-        return nil, err
-    }
+	resp, err := c.PgEdgeAPIClient.Operations.GetBackupStoresID(request)
+	if err != nil {
+		return nil, handleAPIError(err)
+	}
 
-    return resp.Payload, nil
+	return resp.Payload, nil
 }
 
 func (c *Client) DeleteBackupStore(ctx context.Context, id strfmt.UUID) error {
-    request := &operations.DeleteBackupStoresIDParams{
-        HTTPClient: c.HTTPClient,
-        Context:    ctx,
-        ID:         id,
-    }
+	request := &operations.DeleteBackupStoresIDParams{
+		HTTPClient: c.HTTPClient,
+		Context:    ctx,
+		ID:         id,
+	}
 
-    request.SetAuthorization(c.AuthHeader)
+	request.SetAuthorization(c.AuthHeader)
 
-    _, err := c.PgEdgeAPIClient.Operations.DeleteBackupStoresID(request)
-    if err == nil {
+	_, err := c.PgEdgeAPIClient.Operations.DeleteBackupStoresID(request)
+	if err == nil {
 		for {
 			_, err := c.GetBackupStore(ctx, id)
 			if err != nil {
@@ -599,12 +665,10 @@ func (c *Client) DeleteBackupStore(ctx context.Context, id strfmt.UUID) error {
 
 			time.Sleep(5 * time.Second)
 		}
+	}else{
+		return handleAPIError(err)
 	}
-
-	return err	
 }
-
-
 
 func (c *Client) OAuthToken(ctx context.Context, clientId, clientSecret, grantType string) (*operations.PostOauthTokenOKBody, error) {
 	request := &operations.PostOauthTokenParams{
@@ -619,7 +683,7 @@ func (c *Client) OAuthToken(ctx context.Context, clientId, clientSecret, grantTy
 
 	resp, err := c.PgEdgeAPIClient.Operations.PostOauthToken(request)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIError(err)
 	}
 
 	return resp.Payload, nil

--- a/internals/provider/backup-store/data_source.go
+++ b/internals/provider/backup-store/data_source.go
@@ -1,14 +1,15 @@
 package backupstore
 
 import (
-    "context"
-    "fmt"
+	"context"
+	"fmt"
 
-    "github.com/hashicorp/terraform-plugin-framework/attr"
-    "github.com/hashicorp/terraform-plugin-framework/datasource"
-    "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-    "github.com/hashicorp/terraform-plugin-framework/types"
-    pgEdge "github.com/pgEdge/terraform-provider-pgedge/client"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	pgEdge "github.com/pgEdge/terraform-provider-pgedge/client"
+	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
 )
 
 var (
@@ -109,10 +110,7 @@ func (d *backupStoresDataSource) Read(ctx context.Context, req datasource.ReadRe
 
     backupStores, err := d.client.GetBackupStores(ctx, nil, nil, nil, nil, nil)
     if err != nil {
-        resp.Diagnostics.AddError(
-            "Unable to Read pgEdge Backup Stores",
-            err.Error(),
-        )
+        resp.Diagnostics.Append(common.HandleProviderError(err, "reading backup stores"))
         return
     }
 

--- a/internals/provider/backup-store/resource.go
+++ b/internals/provider/backup-store/resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	pgEdge "github.com/pgEdge/terraform-provider-pgedge/client"
 	"github.com/pgEdge/terraform-provider-pgedge/client/models"
+	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
 )
 
 var (
@@ -125,10 +126,7 @@ func (r *backupStoreResource) Create(ctx context.Context, req resource.CreateReq
 
     backupStore, err := r.client.CreateBackupStore(ctx, input)
     if err != nil {
-        resp.Diagnostics.AddError(
-            "Error creating backup store",
-            "Could not create backup store, unexpected error: "+err.Error(),
-        )
+        resp.Diagnostics.Append(common.HandleProviderError(err, "backup store creation"))
         return
     }
 
@@ -165,10 +163,7 @@ func (r *backupStoreResource) Read(ctx context.Context, req resource.ReadRequest
 
     backupStore, err := r.client.GetBackupStore(ctx, strfmt.UUID(state.ID.ValueString()))
     if err != nil {
-        resp.Diagnostics.AddError(
-            "Error Reading pgEdge Backup Store",
-            "Could not read pgEdge backup store ID "+state.ID.ValueString()+": "+err.Error(),
-        )
+        resp.Diagnostics.Append(common.HandleProviderError(err, "reading backup store"))
         return
     }
 
@@ -213,10 +208,7 @@ func (r *backupStoreResource) Delete(ctx context.Context, req resource.DeleteReq
 
     err := r.client.DeleteBackupStore(ctx, strfmt.UUID(state.ID.ValueString()))
     if err != nil {
-        resp.Diagnostics.AddError(
-            "Error Deleting Backup Store",
-            "Could not delete backup store, unexpected error: "+err.Error(),
-        )
+        resp.Diagnostics.Append(common.HandleProviderError(err, "backup store deletion"))
         return
     }
 }

--- a/internals/provider/cloud-account/data_source.go
+++ b/internals/provider/cloud-account/data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	pgEdge "github.com/pgEdge/terraform-provider-pgedge/client"
+	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
 )
 
 var (
@@ -108,12 +109,9 @@ func (d *cloudAccountsDataSource) Read(ctx context.Context, req datasource.ReadR
 
 	cloudAccounts, err := d.client.GetCloudAccounts(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read pgEdge Cloud Accounts",
-			err.Error(),
-		)
-		return
-	}
+        resp.Diagnostics.Append(common.HandleProviderError(err, "reading cloud accounts"))
+        return
+    }
 
 	for _, account := range cloudAccounts {
 		properties := make(map[string]attr.Value)

--- a/internals/provider/cloud-account/data_source_test.go
+++ b/internals/provider/cloud-account/data_source_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
+	common "github.com/pgEdge/terraform-provider-pgedge/internals/provider/common/test-helper"
 )
 
 func TestAccCloudAccountsDataSource(t *testing.T) {

--- a/internals/provider/cloud-account/resource.go
+++ b/internals/provider/cloud-account/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	pgEdge "github.com/pgEdge/terraform-provider-pgedge/client"
 	"github.com/pgEdge/terraform-provider-pgedge/client/models"
+	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
 )
 
 var (
@@ -107,12 +108,9 @@ func (r *cloudAccountResource) Create(ctx context.Context, req resource.CreateRe
 
 	account, err := r.client.CreateCloudAccount(ctx, createInput)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating Cloud Account",
-			"Could not create cloud account, unexpected error: "+err.Error(),
-		)
-		return
-	}
+        resp.Diagnostics.Append(common.HandleProviderError(err, "cloud account creation"))
+        return
+    }
 
 	plan.ID = types.StringValue(account.ID.String())
 	plan.CreatedAt = types.StringValue(*account.CreatedAt)
@@ -135,12 +133,9 @@ func (r *cloudAccountResource) Read(ctx context.Context, req resource.ReadReques
 
 	account, err := r.client.GetCloudAccount(ctx, strfmt.UUID(state.ID.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Cloud Account",
-			"Could not read cloud account ID "+state.ID.ValueString()+": "+err.Error(),
-		)
-		return
-	}
+        resp.Diagnostics.Append(common.HandleProviderError(err, "reading cloud account"))
+        return
+    }
 
 	state.Name = types.StringValue(*account.Name)
 	state.Type = types.StringValue(*account.Type)
@@ -176,10 +171,7 @@ func (r *cloudAccountResource) Delete(ctx context.Context, req resource.DeleteRe
 
 	err := r.client.DeleteCloudAccount(ctx, strfmt.UUID(state.ID.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Deleting Cloud Account",
-			"Could not delete cloud account, unexpected error: "+err.Error(),
-		)
-		return
-	}
+        resp.Diagnostics.Append(common.HandleProviderError(err, "cloud account deletion"))
+        return
+    }
 }

--- a/internals/provider/cloud-account/resource_test.go
+++ b/internals/provider/cloud-account/resource_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
+	common "github.com/pgEdge/terraform-provider-pgedge/internals/provider/common/test-helper"
 )
 
 func TestAccCloudAccountResource(t *testing.T) {

--- a/internals/provider/cluster/data_source.go
+++ b/internals/provider/cluster/data_source.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	pgEdge "github.com/pgEdge/terraform-provider-pgedge/client"
+	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
 )
 
 var (
@@ -293,12 +294,9 @@ func (c *clustersDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	clusters, err := c.client.GetAllClusters(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read pgEdge Clusters",
-			err.Error(),
-		)
-		return
-	}
+        resp.Diagnostics.Append(common.HandleProviderError(err, "reading clusters"))
+        return
+    }
 
 	for _, cluster := range clusters {
 		var clusterDetails ClusterDetails

--- a/internals/provider/cluster/data_source_test.go
+++ b/internals/provider/cluster/data_source_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
+	common "github.com/pgEdge/terraform-provider-pgedge/internals/provider/common/test-helper"
 )
 
 func TestAccClustersDataSource(t *testing.T) {

--- a/internals/provider/cluster/resource.go
+++ b/internals/provider/cluster/resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	pgEdge "github.com/pgEdge/terraform-provider-pgedge/client"
 	"github.com/pgEdge/terraform-provider-pgedge/client/models"
+	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
 )
 
 var (
@@ -293,12 +294,9 @@ func (r *clusterResource) Create(ctx context.Context, req resource.CreateRequest
 
 	cluster, err := r.client.CreateCluster(ctx, createInput)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating cluster",
-			"Could not create cluster, unexpected error: "+err.Error(),
-		)
-		return
-	}
+        resp.Diagnostics.Append(common.HandleProviderError(err, "cluster creation"))
+        return
+    }
 
 	tflog.Debug(ctx, "Created cluster", map[string]interface{}{"cluster": cluster})
 
@@ -413,12 +411,9 @@ func (r *clusterResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	cluster, err := r.client.GetCluster(ctx, strfmt.UUID(state.ID.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading cluster",
-			"Could not read cluster ID "+state.ID.ValueString()+": "+err.Error(),
-		)
-		return
-	}
+        resp.Diagnostics.Append(common.HandleProviderError(err, "reading cluster"))
+        return
+    }
 
 	state.Name = types.StringPointerValue(cluster.Name)
 	state.CloudAccountID = types.StringPointerValue(cluster.CloudAccount.ID)
@@ -637,12 +632,9 @@ func (r *clusterResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	cluster, err := r.client.UpdateCluster(ctx, strfmt.UUID(*plan.ID.ValueStringPointer()), updateInput)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error updating cluster",
-			"Could not update cluster, unexpected error: "+err.Error(),
-		)
-		return
-	}
+        resp.Diagnostics.Append(common.HandleProviderError(err, "updating cluster"))
+        return
+    }
 
 	updatedPlan := r.mapClusterToResourceModel(cluster)
 
@@ -757,12 +749,9 @@ func (r *clusterResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	err := r.client.DeleteCluster(ctx, strfmt.UUID(state.ID.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting cluster",
-			"Could not delete cluster, unexpected error: "+err.Error(),
-		)
-		return
-	}
+        resp.Diagnostics.Append(common.HandleProviderError(err, "cluster deletion"))
+        return
+    }
 }
 
 type clusterResourceModel struct {

--- a/internals/provider/cluster/resource_test.go
+++ b/internals/provider/cluster/resource_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
+	common "github.com/pgEdge/terraform-provider-pgedge/internals/provider/common/test-helper"
 )
 
 func TestAccClusterResource(t *testing.T) {

--- a/internals/provider/common/error_helper.go
+++ b/internals/provider/common/error_helper.go
@@ -1,0 +1,21 @@
+package common
+
+import (
+    "fmt"
+    "github.com/hashicorp/terraform-plugin-framework/diag"
+    "github.com/pgEdge/terraform-provider-pgedge/client"
+)
+
+func HandleProviderError(err error, operation string) diag.Diagnostic {
+    if apiErr, ok := err.(*client.APIError); ok {
+        return diag.NewErrorDiagnostic(
+            fmt.Sprintf("API Error during %s", operation),
+            fmt.Sprintf("Status code: %d, Message: %s", apiErr.StatusCode, apiErr.Message),
+        )
+    } else {
+        return diag.NewErrorDiagnostic(
+            fmt.Sprintf("Error during %s", operation),
+            err.Error(),
+        )
+    }
+}

--- a/internals/provider/common/error_helper.go
+++ b/internals/provider/common/error_helper.go
@@ -1,9 +1,9 @@
 package common
 
 import (
-    "fmt"
-    "github.com/hashicorp/terraform-plugin-framework/diag"
-    "github.com/pgEdge/terraform-provider-pgedge/client"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/pgEdge/terraform-provider-pgedge/client"
 )
 
 func HandleProviderError(err error, operation string) diag.Diagnostic {

--- a/internals/provider/common/test-helper/test_helper.go
+++ b/internals/provider/common/test-helper/test_helper.go
@@ -1,4 +1,4 @@
-package common
+package test_helper
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"

--- a/internals/provider/database/data_source.go
+++ b/internals/provider/database/data_source.go
@@ -96,10 +96,10 @@ func (d *databasesDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 							Computed:    true,
 							Description: "Creation timestamp of the database",
 						},
-						"updated_at": schema.StringAttribute{
-							Computed:    true,
-							Description: "Last update timestamp of the database",
-						},
+						// "updated_at": schema.StringAttribute{
+						// 	Computed:    true,
+						// 	Description: "Last update timestamp of the database",
+						// },
 						"pg_version": schema.StringAttribute{
 							Computed:    true,
 							Description: "PostgreSQL version of the database",

--- a/internals/provider/database/data_source.go
+++ b/internals/provider/database/data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	pgEdge "github.com/pgEdge/terraform-provider-pgedge/client"
 	"github.com/pgEdge/terraform-provider-pgedge/client/models"
+	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
 )
 
 var (
@@ -165,12 +166,9 @@ func (d *databasesDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	databases, err := d.client.GetDatabases(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Read pgEdge Databases",
-			err.Error(),
-		)
-		return
-	}
+        resp.Diagnostics.Append(common.HandleProviderError(err, "reading databases"))
+        return
+    }
 
 	for _, db := range databases {
 		databaseModel := DatabaseModel{

--- a/internals/provider/database/data_source_test.go
+++ b/internals/provider/database/data_source_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
+	common "github.com/pgEdge/terraform-provider-pgedge/internals/provider/common/test-helper"
 )
 
 func TestAccDatabasesDataSource(t *testing.T) {

--- a/internals/provider/database/resource.go
+++ b/internals/provider/database/resource.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	pgEdge "github.com/pgEdge/terraform-provider-pgedge/client"
 	"github.com/pgEdge/terraform-provider-pgedge/client/models"
+	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
 )
 
 var (
@@ -654,12 +655,9 @@ func (r *databaseResource) Create(ctx context.Context, req resource.CreateReques
 
 	database, err := r.client.CreateDatabase(ctx, createInput)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating database",
-			"Could not create database, unexpected error: "+err.Error(),
-		)
-		return
-	}
+        resp.Diagnostics.Append(common.HandleProviderError(err, "database creation"))
+        return
+    }
 
 	// Map response body to schema and populate Computed attribute values
 	plan = r.mapDatabaseToResourceModel(database)
@@ -686,12 +684,9 @@ func (r *databaseResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	database, err := r.client.GetDatabase(ctx, strfmt.UUID(state.ID.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading pgEdge Database",
-			"Could not read pgEdge database ID "+state.ID.ValueString()+": "+err.Error(),
-		)
-		return
-	}
+        resp.Diagnostics.Append(common.HandleProviderError(err, "database retrieval"))
+        return
+    }
 
 	// Map response body to schema and populate Computed attribute values
 	state = r.mapDatabaseToResourceModel(database)
@@ -827,10 +822,7 @@ func (r *databaseResource) Update(ctx context.Context, req resource.UpdateReques
 
 		updatedDatabase, err := r.client.UpdateDatabase(ctx, strfmt.UUID(plan.ID.ValueString()), extensionsUpdateInput)
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error Updating pgEdge Database Options",
-				"Could not update database options, unexpected error: "+err.Error(),
-			)
+			resp.Diagnostics.Append(common.HandleProviderError(err, "database options update"))
 			return
 		}
 		plan = r.mapDatabaseToResourceModel(updatedDatabase)
@@ -858,10 +850,7 @@ func (r *databaseResource) Update(ctx context.Context, req resource.UpdateReques
 
 		updatedDatabase, err := r.client.UpdateDatabase(ctx, strfmt.UUID(plan.ID.ValueString()), extensionsUpdateInput)
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error Updating pgEdge Database Extensions",
-				"Could not update database extensions, unexpected error: "+err.Error(),
-			)
+			resp.Diagnostics.Append(common.HandleProviderError(err, "database extensions update"))
 			return
 		}
 
@@ -883,10 +872,7 @@ func (r *databaseResource) Update(ctx context.Context, req resource.UpdateReques
 
 		updatedDatabase, err := r.client.UpdateDatabase(ctx, strfmt.UUID(plan.ID.ValueString()), nodesUpdateInput)
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error Updating pgEdge Database Nodes",
-				"Could not update database nodes, unexpected error: "+err.Error(),
-			)
+			resp.Diagnostics.Append(common.HandleProviderError(err, "database nodes update"))
 			return
 		}
 
@@ -918,10 +904,7 @@ func (r *databaseResource) Delete(ctx context.Context, req resource.DeleteReques
 
 	err := r.client.DeleteDatabase(ctx, strfmt.UUID(state.ID.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Deleting pgEdge Database",
-			"Could not delete database, unexpected error: "+err.Error(),
-		)
+		resp.Diagnostics.Append(common.HandleProviderError(err, "database deletion"))
 		return
 	}
 

--- a/internals/provider/database/resource_test.go
+++ b/internals/provider/database/resource_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
+	common "github.com/pgEdge/terraform-provider-pgedge/internals/provider/common/test-helper"
 )
 
 func TestAccDatabaseResource(t *testing.T) {

--- a/internals/provider/ssh-key/data_source.go
+++ b/internals/provider/ssh-key/data_source.go
@@ -1,13 +1,14 @@
 package sshkey
 
 import (
-    "context"
-    "fmt"
+	"context"
+	"fmt"
 
-    "github.com/hashicorp/terraform-plugin-framework/datasource"
-    "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-    "github.com/hashicorp/terraform-plugin-framework/types"
-    pgEdge "github.com/pgEdge/terraform-provider-pgedge/client"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	pgEdge "github.com/pgEdge/terraform-provider-pgedge/client"
+	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
 )
 
 var (
@@ -91,10 +92,7 @@ func (d *sshKeysDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
     sshKeys, err := d.client.GetSSHKeys(ctx)
     if err != nil {
-        resp.Diagnostics.AddError(
-            "Unable to Read pgEdge SSH Keys",
-            err.Error(),
-        )
+        resp.Diagnostics.Append(common.HandleProviderError(err, "ssh key retrieval"))
         return
     }
 

--- a/internals/provider/ssh-key/resource.go
+++ b/internals/provider/ssh-key/resource.go
@@ -1,18 +1,19 @@
 package sshkey
 
 import (
-    "context"
-    "fmt"
+	"context"
+	"fmt"
 
-    "github.com/go-openapi/strfmt"
-    "github.com/hashicorp/terraform-plugin-framework/path"
-    "github.com/hashicorp/terraform-plugin-framework/resource"
-    "github.com/hashicorp/terraform-plugin-framework/resource/schema"
-    "github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-    "github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-    "github.com/hashicorp/terraform-plugin-framework/types"
-    pgEdge "github.com/pgEdge/terraform-provider-pgedge/client"
-    "github.com/pgEdge/terraform-provider-pgedge/client/models"
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	pgEdge "github.com/pgEdge/terraform-provider-pgedge/client"
+	"github.com/pgEdge/terraform-provider-pgedge/client/models"
+	"github.com/pgEdge/terraform-provider-pgedge/internals/provider/common"
 )
 
 var (
@@ -99,10 +100,7 @@ func (r *sshKeyResource) Create(ctx context.Context, req resource.CreateRequest,
 
     sshKey, err := r.client.CreateSSHKey(ctx, createInput)
     if err != nil {
-        resp.Diagnostics.AddError(
-            "Error creating SSH key",
-            "Could not create SSH key, unexpected error: "+err.Error(),
-        )
+        resp.Diagnostics.Append(common.HandleProviderError(err, "ssh key creation"))
         return
     }
 
@@ -126,10 +124,7 @@ func (r *sshKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 
     sshKey, err := r.client.GetSSHKey(ctx, strfmt.UUID(state.ID.ValueString()))
     if err != nil {
-        resp.Diagnostics.AddError(
-            "Error Reading SSH Key",
-            "Could not read SSH key ID "+state.ID.ValueString()+": "+err.Error(),
-        )
+        resp.Diagnostics.Append(common.HandleProviderError(err, "ssh key retrieval"))
         return
     }
 
@@ -162,10 +157,7 @@ func (r *sshKeyResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
     err := r.client.DeleteSSHKey(ctx, strfmt.UUID(state.ID.ValueString()))
     if err != nil {
-        resp.Diagnostics.AddError(
-            "Error Deleting SSH Key",
-            "Could not delete SSH key, unexpected error: "+err.Error(),
-        )
+        resp.Diagnostics.Append(common.HandleProviderError(err, "ssh key deletion"))
         return
     }
 }


### PR DESCRIPTION

This PR ensures well formatted error message to terraform logs with seperated message and error code. 
<img width="704" alt="image" src="https://github.com/user-attachments/assets/2f6ce060-d773-4d92-8d68-af7c25df0107">
