### PR TITLE
Fix unnecessary node extensions diff in Terraform plan

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -328,7 +328,7 @@ func (c *Client) UpdateDatabase(ctx context.Context, id strfmt.UUID, body *model
 		return nil, err
 	}
 
-	return c.GetDatabase(ctx, *resp.Payload.ID)
+	return c.GetDatabase(ctx, id)
 }
 
 func (c *Client) DeleteDatabase(ctx context.Context, id strfmt.UUID) error {

--- a/client/models/extensions.go
+++ b/client/models/extensions.go
@@ -8,8 +8,10 @@ package models
 import (
 	"context"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // Extensions extensions
@@ -18,7 +20,8 @@ import (
 type Extensions struct {
 
 	// auto manage
-	AutoManage bool `json:"auto_manage,omitempty"`
+	// Required: true
+	AutoManage *bool `json:"auto_manage"`
 
 	// available
 	Available []string `json:"available"`
@@ -29,6 +32,24 @@ type Extensions struct {
 
 // Validate validates this extensions
 func (m *Extensions) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateAutoManage(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *Extensions) validateAutoManage(formats strfmt.Registry) error {
+
+	if err := validate.Required("auto_manage", "body", m.AutoManage); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/client/swagger/databases.yaml
+++ b/client/swagger/databases.yaml
@@ -240,6 +240,8 @@ definitions:
         $ref: "#/definitions/Backups"
   Extensions:
     type: object
+    required:
+      - auto_manage
     properties:
       auto_manage:
         type: boolean

--- a/client/swagger/swagger.yaml
+++ b/client/swagger/swagger.yaml
@@ -741,6 +741,8 @@ definitions:
         items:
           type: string
         type: array
+    required:
+    - auto_manage
     type: object
   GoogleCredentials:
     properties:

--- a/internals/provider/database/data_source.go
+++ b/internals/provider/database/data_source.go
@@ -568,7 +568,7 @@ func (d *databasesDataSource) mapExtensionsToModel(extensions *models.Extensions
             "requested":   types.ListType{ElemType: types.StringType},
         },
         map[string]attr.Value{
-            "auto_manage": types.BoolValue(extensions.AutoManage),
+            "auto_manage": types.BoolPointerValue(extensions.AutoManage),
             "available":   d.convertToListValue(extensions.Available),
             "requested":   d.convertToListValue(extensions.Requested),
         },

--- a/internals/provider/database/resource.go
+++ b/internals/provider/database/resource.go
@@ -468,7 +468,7 @@ func (r *databaseResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 							Attributes: map[string]schema.Attribute{
 								"database":            schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 								"host":                schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
-								"password":            schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
+								"password":            schema.StringAttribute{Computed: true, Sensitive: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 								"port":                schema.Int64Attribute{Computed: true, PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()}},
 								"username":            schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},
 								"external_ip_address": schema.StringAttribute{Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()}},


### PR DESCRIPTION
Prevents terraform plan from showing diffs for node.extensions when extensions are unmanaged or when making unrelated resource changes. Only shows extension diffs when explicitly managing extensions with auto_manage = true.